### PR TITLE
fix: add file changes process only git tracked files

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -19,7 +19,6 @@ describe('Git CLI', () => {
       const execMock = jest.spyOn(exec, 'exec').mockResolvedValue(0)
 
       await switchBranch('new-branch')
-      expect(execMock).toHaveBeenCalled()
       expect(execMock).toHaveBeenCalledWith(
         'git',
         ['checkout', '-b', 'new-branch'],
@@ -97,7 +96,6 @@ describe('Git CLI', () => {
         .mockReturnValue(false)
 
       await pushCurrentBranch()
-      expect(execMock).toHaveBeenCalled()
       expect(execMock).toHaveBeenCalledWith(
         'git',
         ['push', '--porcelain', '--set-upstream', 'origin', 'HEAD'],
@@ -190,7 +188,6 @@ describe('Git CLI', () => {
       const execMock = jest.spyOn(exec, 'exec').mockResolvedValue(0)
 
       await addFileChanges(['*.ts', '~/.bashrc'])
-      expect(execMock).toHaveBeenCalled()
       expect(execMock).toHaveBeenCalledWith(
         'git',
         ['add', '--', '/test-workspace/*.ts', '/test-workspace/~/.bashrc'],
@@ -284,7 +281,13 @@ describe('Git CLI', () => {
         })
 
       const changes = await getFileChanges()
-      expect(execMock).toHaveBeenCalled()
+      expect(execMock).toHaveBeenCalledWith(
+        'git',
+        ['status', '-suno', '--porcelain'],
+        expect.objectContaining({
+          listeners: { stdline: expect.anything(), errline: expect.anything() },
+        })
+      )
       expect(changes).toBeDefined()
       expect(changes.additions).toBeDefined()
       expect(changes.additions).toHaveLength(5)

--- a/dist/index.js
+++ b/dist/index.js
@@ -30578,7 +30578,7 @@ function processFileChanges(output) {
 }
 function getFileChanges() {
     return __awaiter(this, void 0, void 0, function* () {
-        const { debug } = yield execGit(['status', '-suall', '--porcelain']);
+        const { debug } = yield execGit(['status', '-suno', '--porcelain']);
         const { additions, deletions } = processFileChanges(debug);
         const filesChanges = {};
         if (additions.length > 0) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -88,7 +88,7 @@ function processFileChanges(output: string[]) {
 }
 
 export async function getFileChanges(): Promise<FileChanges> {
-  const { debug } = await execGit(['status', '-suall', '--porcelain'])
+  const { debug } = await execGit(['status', '-suno', '--porcelain'])
   const { additions, deletions } = processFileChanges(debug)
   const filesChanges: FileChanges = {}
   if (additions.length > 0) {


### PR DESCRIPTION
since we use `git add` to ensure the files from the input will be tracked by git. We should skip untracked files when processing `git status` output