### PR TITLE
feat: Add support for remote GitHub owner and repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,16 +14,24 @@ inputs:
     description: |
       Directory containing files to be committed. Default: GitHub workspace directory (root of repository).
     required: false
-    default: ''
+    default: ""
   commit-message:
     description: |
       Commit message for the file changes.
+    required: false
+  owner:
+    description: |
+      GitHub repository owner (user or organization), defaults to the repo invoking the action.
+    required: false
+  repo:
+    description: |
+      GitHub repository name, defaults to the repo invoking the action.
     required: false
   branch-name:
     description: |
       Branch to commit to. Default: Workflow triggered branch.
     required: false
-    default: ''
+    default: ""
   branch-push-force:
     description: |
       --force flag when running git push <branch-name>.
@@ -33,7 +41,7 @@ inputs:
     description: |
       Push tag for the new/current commit.
     required: false
-    default: ''
+    default: ""
   tag-only-if-file-changes:
     description: |
       Push tag for new commit only when file changes present.

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,18 +23,28 @@ import {
 
 export async function run(): Promise<void> {
   try {
+    core.info('Getting info from context')
     const { owner, repo, branch } = getContext()
+
+    core.debug('Setting branch according to input and context')
     const inputBranch = getInput('branch-name')
     if (inputBranch && inputBranch !== branch) {
       await switchBranch(inputBranch)
       await pushCurrentBranch()
     }
     const currentBranch = inputBranch ? inputBranch : branch
+
+    const inputOwner = getInput('owner')
+    const currentOwner = inputOwner ? inputOwner : owner
+
+    const inputRepo = getInput('repo')
+    const currentRepo = inputRepo ? inputRepo : repo
+
     const repository = await core.group(
-      `fetching repository info for owner: ${owner}, repo: ${repo}, branch: ${currentBranch}`,
+      `fetching repository info for owner: ${currentOwner}, repo: ${currentRepo}, branch: ${currentBranch}`,
       async () => {
         const startTime = Date.now()
-        const repositoryData = await getRepository(owner, repo, currentBranch)
+        const repositoryData = await getRepository(currentOwner, currentRepo, currentBranch)
         const endTime = Date.now()
         core.debug(`time taken: ${(endTime - startTime).toString()} ms`)
         return repositoryData


### PR DESCRIPTION
- Update default values for `commit-message`, `owner`, `repo`, `branch-name`, `branch-push-force`, and `tag-only-if-file-changes`
- Add logging for getting info from context and setting branch according to input and context in `main.ts`
- Update repository info fetching message with input owner and repo in `main.ts`
